### PR TITLE
[Fix]ショッピングカート同じ商品の数量変更機能を追加

### DIFF
--- a/app/assets/stylesheets/public/orders.scss
+++ b/app/assets/stylesheets/public/orders.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/orders controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -7,13 +7,14 @@ class Public::AddressesController < ApplicationController
       redirect_to addresses_path
       flash[:notice] = "新しい配送先を登録しました。"
     else
+      @addresses = current_customer.addresses
       render :index
     end
   end
 
   def index
     @address = Address.new
-    @addresses = Address.all
+    @addresses = current_customer.addresses
   end
 
   def edit

--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -3,18 +3,22 @@ class Public::CartItemsController < ApplicationController
 
   def create
     @cart_item = CartItem.new(cart_item_params)
-    if @cart_item.save
-      redirect_to cart_items_path
-    else
-      @customer = current_customer
-      @cart_items = CartItem.all
-      render :index
-    end
+    @customer = current_customer
+      if current_customer.cart_items.find_by(item_id: params[:cart_item][:item_id]).present?
+        cart_item = current_customer.cart_items.find_by(item_id: params[:cart_item][:item_id])
+        cart_item.amount += (params[:cart_item][:amount]).to_i
+        cart_item.save
+        redirect_to cart_items_path
+      elsif @cart_item.save
+        redirect_to cart_items_path
+      else
+        @cart_items = current_customer.cart_items
+        render :index
+      end
   end
 
   def index
-    @cart_items = CartItem.all
-    @customer = current_customer
+    @cart_items = current_customer.cart_items
     @sum = 0
   end
 
@@ -27,12 +31,11 @@ class Public::CartItemsController < ApplicationController
   def destroy
     cart_item = CartItem.find(params[:id])
     cart_item.destroy
-    @cart_items = CartItem.all
     redirect_to cart_items_path
   end
 
   def destroy_all  #カート内全て削除
-    cart_items = CartItem.all
+    cart_items = current_customer.cart_items
     cart_items.destroy_all
     redirect_to cart_items_path
   end

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -33,6 +33,6 @@ class Public::CustomersController < ApplicationController
   private
 
   def customer_params
-   params.require(:customer).permit(:customer_id, :last_name, :first_name, :last_name_kana, :first_name_kana, :email, :postal_code, :address, :telephone_number, :is_delete)
+   params.require(:customer).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :email, :postal_code, :address, :telephone_number, :is_delete)
   end
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,0 +1,18 @@
+class Public::OrdersController < ApplicationController
+  before_action :authenticate_customer!
+  
+  def new
+  end
+
+  def confirm
+  end
+
+  def complete
+  end
+
+  def index
+  end
+
+  def show
+  end
+end

--- a/app/helpers/public/orders_helper.rb
+++ b/app/helpers/public/orders_helper.rb
@@ -1,0 +1,2 @@
+module Public::OrdersHelper
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -6,6 +6,7 @@ class Customer < ApplicationRecord
 
   has_many :cart_items
   has_many :addresses
+  has_many :orders
   validates :last_name, presence: true
   validates :first_name, presence: true
   validates :last_name_kana, presence: true

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,2 +1,4 @@
 class Order < ApplicationRecord
+  belongs_to :customer
+  enum payment_method: { credit_card: 0, transfer: 1 }
 end

--- a/app/views/public/orders/complete.html.erb
+++ b/app/views/public/orders/complete.html.erb
@@ -1,0 +1,2 @@
+<h1>Public::Orders#complete</h1>
+<p>Find me in app/views/public/orders/complete.html.erb</p>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -1,0 +1,2 @@
+<h1>Public::Orders#confirm</h1>
+<p>Find me in app/views/public/orders/confirm.html.erb</p>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Public::Orders#index</h1>
+<p>Find me in app/views/public/orders/index.html.erb</p>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Public::Orders#new</h1>
+<p>Find me in app/views/public/orders/new.html.erb</p>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Public::Orders#show</h1>
+<p>Find me in app/views/public/orders/show.html.erb</p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,4 +21,9 @@ ja:
         postal_code: 郵便番号
         address: 住所
 
-
+  ja:
+    enums:
+      order:
+        payment_method:
+          credit_card: "クレジットカード"
+          transfer: "銀行振込"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,10 +12,14 @@ Rails.application.routes.draw do
     delete "/cart_items/destroy_all" => "cart_items#destroy_all"
     post "/customers/confirm" => "customers#confirm"
     patch "/customers/update_status" => "customers#update_status"
+    post "/orders/confirm" => "orders#confirm"
+    get "/orders/complete" => "orders#complete"
+
     resources :items, only:[:index, :show]
     resources :cart_items, only:[:index, :update, :destroy, :create]
     resources :customers, only:[:show, :edit, :update]
     resources :addresses, only:[:index, :edit, :create, :update, :destroy]
+    resources :orders, only:[:new, :index, :show]
   end
 
   #管理側のルーティング設定

--- a/test/controllers/public/orders_controller_test.rb
+++ b/test/controllers/public/orders_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class Public::OrdersControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get public_orders_new_url
+    assert_response :success
+  end
+
+  test "should get confirm" do
+    get public_orders_confirm_url
+    assert_response :success
+  end
+
+  test "should get complete" do
+    get public_orders_complete_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get public_orders_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get public_orders_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
ショッピングカートにて同じ商品を追加した際、別の商品として追加されていたので、
同じ商品として数量を変更できるよう記述を追加・編集した。